### PR TITLE
fix Ctrl-Z deletion bug

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -232,7 +232,11 @@ class Editor {
 
     handleUserEdit(evt) {
         evt.preventDefault();
-        const start = this.prevState.selectionStart;
+        const start = (
+            (this.prevState.selectionStart > this.targetTextArea.selectionStart)
+            ? this.targetTextArea.selectionStart
+            : this.prevState.selectionStart
+        );
         const end = this.prevState.selectionEnd;
         const newEnd = this.targetTextArea.selectionEnd;
         const oldText = this.prevState.content.substring(start, end);


### PR DESCRIPTION
Ctrl-Z (and Ctrl-Shift-Z/Ctrl-Y) wouldn't work well with deletions, and it would mess code history. This PR fixes it.